### PR TITLE
Specify access since scoped pkgs are private by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: ./scripts/bump_npm_version.sh
       - run:
           name: Publish to NPM Registry
-          command: pnpm publish --no-git-checks
+          command: pnpm publish --no-git-checks --access public 
 
 workflows:
   main:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Specifies npm publish access to `public` since the package is now scoped and scoped packages default to `private`
